### PR TITLE
V1.4.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@
 /test/acceptance/fixtures/files-watch
 /test/acceptance/fixtures/mocks
 /testing.js
+/mocks-server.config.js
 
 # misc
 .DS_Store

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Add "disableCommandLineArguments" configuration.
 - Add "disableConfigFile" configuration.
 - Load configuration and options from file.
+- Options can also be passed to the Core Constructor, using the "options" key in the config object.
 
 ## [1.3.0] - 2020-01-03
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,8 +26,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 ### Removed
 
-## [1.4.0] - 2020-01-07
+## [1.4.0] - 2020-01-06
 ### Added
+- Add "addPlugins" configuration.
+- Add "disableCommandLineArguments" configuration.
+- Add "disableConfigFile" configuration.
+- Load configuration and options from file.
 
 ## [1.3.0] - 2020-01-03
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 ### Removed
 
+## [1.4.0] - 2020-01-07
+### Added
+
 ## [1.3.0] - 2020-01-03
 ### Added
 - Behaviors can now be defined in json format.

--- a/jest.acceptance.config.js
+++ b/jest.acceptance.config.js
@@ -6,7 +6,7 @@ module.exports = {
   clearMocks: true,
 
   testMatch: ["**/test/acceptance/**/?(*.)+(spec|test).js?(x)"],
-  // testMatch: ["**/test/acceptance/plugins-load-method.spec.js"],
+  // testMatch: ["**/test/acceptance/config-file-add-plugins.spec.js"],
 
   // Indicates whether the coverage information should be collected while executing the test
   collectCoverage: false,

--- a/jest.config.js
+++ b/jest.config.js
@@ -26,7 +26,7 @@ module.exports = {
 
   // The glob patterns Jest uses to detect test files
   testMatch: ["**/test/unit/**/?(*.)+(spec|test).js?(x)"],
-  // testMatch: ["**/test/unit/plugins/Plugins.spec.js"],
+  // testMatch: ["**/test/unit/Config.spec.js"],
 
   // The test environment that will be used for testing
   testEnvironment: "node"

--- a/jest.config.js
+++ b/jest.config.js
@@ -26,7 +26,7 @@ module.exports = {
 
   // The glob patterns Jest uses to detect test files
   testMatch: ["**/test/unit/**/?(*.)+(spec|test).js?(x)"],
-  // testMatch: ["**/test/unit/mocks/FixturesGroup.spec.js"],
+  // testMatch: ["**/test/unit/plugins/Plugins.spec.js"],
 
   // The test environment that will be used for testing
   testEnvironment: "node"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@mocks-server/core",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1392,7 +1392,7 @@
         },
         "strip-ansi": {
           "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
           "requires": {
@@ -3858,7 +3858,7 @@
     },
     "is-obj": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
+      "resolved": "http://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
       "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
       "dev": true
     },
@@ -5076,7 +5076,7 @@
         },
         "chalk": {
           "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
@@ -5114,7 +5114,7 @@
         },
         "strip-ansi": {
           "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
           "requires": {
@@ -7234,7 +7234,7 @@
     },
     "through": {
       "version": "2.3.8",
-      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "resolved": "http://registry.npmjs.org/through/-/through-2.3.8.tgz",
       "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
       "dev": true
     },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mocks-server/core",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "description": "Pluggable mocks server supporting multiple api behaviors",
   "keywords": [
     "mocks",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mocks-server/core",
   "version": "1.4.0",
-  "description": "Pluggable mocks server supporting multiple api behaviors",
+  "description": "Pluggable mock server supporting multiple api behaviors",
   "keywords": [
     "mocks",
     "server",

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,6 +1,6 @@
 sonar.organization=mocks-server
 sonar.projectKey=mocks-server-core
-sonar.projectVersion=1.3.0
+sonar.projectVersion=1.4.0
 
 sonar.javascript.file.suffixes=.js
 sonar.sourceEncoding=UTF-8

--- a/src/Config.js
+++ b/src/Config.js
@@ -1,0 +1,123 @@
+const path = require("path");
+const fsExtra = require("fs-extra");
+
+const tracer = require("./tracer");
+const isPromise = require("is-promise");
+const { isFunction, isObject } = require("lodash");
+
+const CONFIG_FILE = "mocks-server.config.js";
+
+class Config {
+  constructor(programmaticConfig = {}) {
+    this._coreOptions = {};
+    this._options = {};
+    this._getCoreOptions(programmaticConfig);
+    this._getOptions(programmaticConfig.options);
+  }
+
+  init(options) {
+    this._getOptions(options);
+    return this._getFileConfig();
+  }
+
+  _catchFileConfigError(error) {
+    tracer.error("Error in configuration file");
+    console.log(error);
+    return Promise.resolve({});
+  }
+
+  _readFileConfig(configFilePath) {
+    tracer.info("Reading configuration file");
+    try {
+      const configFile = require(configFilePath);
+      if (isFunction(configFile)) {
+        const configFileResult = configFile(this.coreOptions);
+        if (isPromise(configFileResult)) {
+          return configFileResult
+            .then(fileConfig => {
+              if (!isObject(fileConfig)) {
+                return Promise.reject(
+                  new Error("Configuration file promise should return an object")
+                );
+              }
+              return Promise.resolve(fileConfig);
+            })
+            .catch(error => {
+              return this._catchFileConfigError(error);
+            });
+        } else if (isObject(configFileResult)) {
+          return Promise.resolve(configFileResult);
+        }
+        throw new Error("Configuration file function should return an object or a promise");
+      } else if (isObject(configFile)) {
+        return Promise.resolve(configFile);
+      }
+      throw new Error("Configuration file should export an object or a function");
+    } catch (error) {
+      return this._catchFileConfigError(error);
+    }
+  }
+
+  _getFileConfigPath(filePath) {
+    if (path.isAbsolute(filePath)) {
+      return filePath;
+    }
+    return path.resolve(process.cwd(), filePath);
+  }
+
+  _getFileConfig() {
+    if (this._coreOptions.disableConfigFile) {
+      tracer.info(`Configuration file is disabled`);
+      return Promise.resolve();
+    }
+    const configFilePath = this._getFileConfigPath(this._coreOptions.configFile || CONFIG_FILE);
+    return fsExtra.pathExists(configFilePath).then(exists => {
+      if (!exists) {
+        tracer.info(`Configuration file not found`);
+        return Promise.resolve();
+      }
+      return this._readFileConfig(configFilePath).then(fileConfig => {
+        tracer.info(`Configuration file successfully loaded`);
+        this._getCoreOptions(fileConfig);
+        this._getOptions(fileConfig.options);
+        tracer.debug(`Config in file: ${JSON.stringify(fileConfig, null, 2)}`);
+        return Promise.resolve();
+      });
+    });
+  }
+
+  _getOptions(options) {
+    this._options = {
+      ...this._options,
+      ...options
+    };
+    if (this._options.log) {
+      tracer.set(this._options.log);
+    }
+  }
+
+  _getCoreOptions(config) {
+    if (config.onlyProgrammaticOptions) {
+      this._coreOptions.disableCommandLineArguments = true;
+      this._coreOptions.disableConfigFile = true;
+    }
+    if (config.hasOwnProperty("disableCommandLineArguments")) {
+      this._coreOptions.disableCommandLineArguments = config.disableCommandLineArguments;
+    }
+    if (config.hasOwnProperty("disableConfigFile")) {
+      this._coreOptions.disableConfigFile = config.disableConfigFile;
+    }
+    this._coreOptions.plugins = config.plugins;
+    this._coreOptions.configFile = config.configFile;
+  }
+
+  get coreOptions() {
+    return this._coreOptions;
+  }
+
+  get options() {
+    return this._options;
+  }
+}
+
+module.exports = Config;

--- a/src/Config.js
+++ b/src/Config.js
@@ -1,3 +1,13 @@
+/*
+Copyright 2019 Javier Brea
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+*/
+
 const path = require("path");
 const fsExtra = require("fs-extra");
 

--- a/src/Config.js
+++ b/src/Config.js
@@ -27,6 +27,7 @@ class Config {
   }
 
   _readConfigFileSuccess(configFileResult) {
+    delete this._coreOptions.options;
     tracer.info(`Configuration file successfully loaded`);
     return Promise.resolve(configFileResult);
   }
@@ -36,7 +37,8 @@ class Config {
     try {
       const configFile = require(configFilePath);
       if (isFunction(configFile)) {
-        const configFileResult = configFile(this.coreOptions);
+        this._coreOptions.options = this._options;
+        const configFileResult = configFile(this._coreOptions);
         if (isPromise(configFileResult)) {
           return configFileResult
             .then(fileConfig => {

--- a/src/Config.js
+++ b/src/Config.js
@@ -26,6 +26,11 @@ class Config {
     return Promise.resolve({});
   }
 
+  _readConfigFileSuccess(configFileResult) {
+    tracer.info(`Configuration file successfully loaded`);
+    return Promise.resolve(configFileResult);
+  }
+
   _readFileConfig(configFilePath) {
     tracer.info("Reading configuration file");
     try {
@@ -40,17 +45,17 @@ class Config {
                   new Error("Configuration file promise should return an object")
                 );
               }
-              return Promise.resolve(fileConfig);
+              return this._readConfigFileSuccess(fileConfig);
             })
             .catch(error => {
               return this._catchFileConfigError(error);
             });
         } else if (isObject(configFileResult)) {
-          return Promise.resolve(configFileResult);
+          return this._readConfigFileSuccess(configFileResult);
         }
         throw new Error("Configuration file function should return an object or a promise");
       } else if (isObject(configFile)) {
-        return Promise.resolve(configFile);
+        return this._readConfigFileSuccess(configFile);
       }
       throw new Error("Configuration file should export an object or a function");
     } catch (error) {
@@ -77,7 +82,6 @@ class Config {
         return Promise.resolve();
       }
       return this._readFileConfig(configFilePath).then(fileConfig => {
-        tracer.info(`Configuration file successfully loaded`);
         this._getCoreOptions(fileConfig);
         this._getOptions(fileConfig.options);
         tracer.debug(`Config in file: ${JSON.stringify(fileConfig, null, 2)}`);

--- a/src/Config.js
+++ b/src/Config.js
@@ -116,6 +116,10 @@ class Config {
     if (config.hasOwnProperty("plugins")) {
       this._coreOptions.plugins = config.plugins;
     }
+    if (config.hasOwnProperty("addPlugins")) {
+      this._coreOptions.plugins = this._coreOptions.plugins || [];
+      this._coreOptions.plugins = this._coreOptions.plugins.concat(config.addPlugins);
+    }
     if (config.hasOwnProperty("configFile")) {
       this._coreOptions.configFile = config.configFile;
     }

--- a/src/Config.js
+++ b/src/Config.js
@@ -111,8 +111,12 @@ class Config {
     if (config.hasOwnProperty("disableConfigFile")) {
       this._coreOptions.disableConfigFile = config.disableConfigFile;
     }
-    this._coreOptions.plugins = config.plugins;
-    this._coreOptions.configFile = config.configFile;
+    if (config.hasOwnProperty("plugins")) {
+      this._coreOptions.plugins = config.plugins;
+    }
+    if (config.hasOwnProperty("configFile")) {
+      this._coreOptions.configFile = config.configFile;
+    }
   }
 
   get coreOptions() {

--- a/src/plugins/Plugins.js
+++ b/src/plugins/Plugins.js
@@ -17,21 +17,21 @@ const tracer = require("../tracer");
 const FilesLoader = require("./FilesLoader");
 
 class Plugins {
-  constructor(plugins, loaders, core) {
+  constructor(config, loaders, core) {
+    this._config = config;
     this._core = core;
     this._loaders = loaders;
-    this._plugins = plugins || [];
     this._pluginsInstances = [];
     this._pluginsMethods = [];
     this._pluginsRegistered = 0;
     this._pluginsInitialized = 0;
     this._pluginsStarted = 0;
     this._pluginsStopped = 0;
-
-    this._plugins.unshift(FilesLoader);
   }
 
   register() {
+    this._plugins = this._config.coreOptions.plugins || [];
+    this._plugins.unshift(FilesLoader);
     return this._registerPlugins().then(() => {
       tracer.verbose(`Registered ${this._pluginsRegistered} plugins without errors`);
       return Promise.resolve();

--- a/src/settings/Options.js
+++ b/src/settings/Options.js
@@ -36,8 +36,8 @@ const DEPRECATED_OPTIONS = {
 };
 
 class Options {
-  constructor(coreOptions = {}) {
-    this._onlyProgrammaticOptions = coreOptions.onlyProgrammaticOptions;
+  constructor(config) {
+    this._config = config;
     this._options = {};
     this._optionsNames = Object.keys(DEFAULT_OPTIONS);
     this._customDefaults = {};
@@ -46,15 +46,15 @@ class Options {
     this._commandLineArguments = new CommandLineArguments(DEFAULT_OPTIONS);
   }
 
-  async init(options) {
+  async init() {
     if (!this._initialized) {
       this._initialized = true;
       const baseOptions = {
         ...DEFAULT_OPTIONS,
         ...this._customDefaults,
-        ...options
+        ...this._config.options
       };
-      if (!this._onlyProgrammaticOptions) {
+      if (!this._config.coreOptions.disableCommandLineArguments) {
         await this._commandLineArguments.init();
         this._options = this._getValidOptions(
           this._removeDeprecatedOptions({

--- a/src/settings/Settings.js
+++ b/src/settings/Settings.js
@@ -15,9 +15,9 @@ const tracer = require("../tracer");
 const { CHANGE_SETTINGS } = require("../eventNames");
 
 class Settings {
-  constructor(eventEmitter, coreOptions) {
+  constructor(eventEmitter, config) {
     this._eventEmitter = eventEmitter;
-    this._optionsHandler = new Options(coreOptions);
+    this._optionsHandler = new Options(config);
     this._emitChange = this._emitChange.bind(this); //Add debounce here to group change events
     this._newSettings = {};
   }

--- a/src/tracer.js
+++ b/src/tracer.js
@@ -1,5 +1,6 @@
 /*
 Copyright 2019 XbyOrange
+Copyright 2019 Javier Brea
 
 Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at
 

--- a/test/acceptance/config-file-add-plugins.spec.js
+++ b/test/acceptance/config-file-add-plugins.spec.js
@@ -1,0 +1,63 @@
+/*
+Copyright 2019 Javier Brea
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+*/
+
+const path = require("path");
+const { CliRunner, request, wait } = require("./utils");
+
+describe("when using config file", () => {
+  const binaryPath = "./starter-add-plugins";
+  const cwdPath = path.resolve(__dirname, "fixtures", "config-files");
+  let cli;
+
+  describe("When started", () => {
+    beforeAll(async () => {
+      cli = new CliRunner([binaryPath], {
+        cwd: cwdPath
+      });
+      await wait();
+    });
+
+    afterAll(async () => {
+      await cli.kill();
+    });
+
+    it("should have log level silly", async () => {
+      expect(cli.logs).toEqual(expect.stringContaining("[Mocks silly]"));
+    });
+
+    it("should load TraceMocksPlugin", async () => {
+      expect(cli.logs).toEqual(expect.stringContaining("traceMocks plugin started"));
+      expect(cli.logs).toEqual(expect.stringContaining("There are 3 behaviors available"));
+    });
+
+    it("should load TraceMocksPlugin2", async () => {
+      expect(cli.logs).toEqual(expect.stringContaining("traceMocks2 plugin started"));
+      expect(cli.logs).toEqual(expect.stringContaining("Hey!, 3 behaviors available"));
+    });
+
+    it("should serve users collection mock under the /api/users path", async () => {
+      const users = await request("/api/users");
+      expect(users).toEqual([
+        { id: 1, name: "John Doe" },
+        { id: 2, name: "Jane Doe" }
+      ]);
+    });
+
+    it("should serve user 2 under the /api/users/1 path", async () => {
+      const users = await request("/api/users/1");
+      expect(users).toEqual({ id: 2, name: "Jane Doe" });
+    });
+
+    it("should serve user 2 under the /api/users/2 path", async () => {
+      const users = await request("/api/users/2");
+      expect(users).toEqual({ id: 2, name: "Jane Doe" });
+    });
+  });
+});

--- a/test/acceptance/config-file.spec.js
+++ b/test/acceptance/config-file.spec.js
@@ -1,0 +1,58 @@
+/*
+Copyright 2019 Javier Brea
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+*/
+
+const path = require("path");
+const { CliRunner, request, wait } = require("./utils");
+
+describe("when using config file", () => {
+  const binaryPath = "./starter";
+  const cwdPath = path.resolve(__dirname, "fixtures", "config-files");
+  let cli;
+
+  describe("When started", () => {
+    beforeAll(async () => {
+      cli = new CliRunner([binaryPath], {
+        cwd: cwdPath
+      });
+      await wait();
+    });
+
+    afterAll(async () => {
+      await cli.kill();
+    });
+
+    it("should have log level silly", async () => {
+      expect(cli.logs).toEqual(expect.stringContaining("[Mocks silly]"));
+    });
+
+    it("should load TraceMocksPlugin", async () => {
+      expect(cli.logs).toEqual(expect.stringContaining("traceMocks plugin started"));
+      expect(cli.logs).toEqual(expect.stringContaining("There are 3 behaviors available"));
+    });
+
+    it("should serve users collection mock under the /api/users path", async () => {
+      const users = await request("/api/users");
+      expect(users).toEqual([
+        { id: 1, name: "John Doe" },
+        { id: 2, name: "Jane Doe" }
+      ]);
+    });
+
+    it("should serve user 2 under the /api/users/1 path", async () => {
+      const users = await request("/api/users/1");
+      expect(users).toEqual({ id: 2, name: "Jane Doe" });
+    });
+
+    it("should serve user 2 under the /api/users/2 path", async () => {
+      const users = await request("/api/users/2");
+      expect(users).toEqual({ id: 2, name: "Jane Doe" });
+    });
+  });
+});

--- a/test/acceptance/fixtures/config-files/TraceMocksPlugin.js
+++ b/test/acceptance/fixtures/config-files/TraceMocksPlugin.js
@@ -1,0 +1,54 @@
+class Plugin {
+  constructor(core) {
+    core.addSetting({
+      name: "traceMocks",
+      type: "boolean",
+      description: "Trace mocks changes",
+      default: true
+    });
+
+    this._core = core;
+    this._onChangeMocks = this._onChangeMocks.bind(this);
+    this._onChangeSettings = this._onChangeSettings.bind(this);
+  }
+
+  get displayName() {
+    return "trace-mocks";
+  }
+
+  init(core) {
+    this._enabled = core.settings.get("traceMocks");
+    this._removeChangeMocksListener = core.onChangeMocks(this.onChangeMocks);
+    this._removeChangeSettingsListener = core.onChangeSettings(this.onChangeSettings);
+    core.tracer.debug(`traceMocks initial value is ${core.settings.get("traceMocks")}`);
+  }
+
+  traceBehaviors() {
+    if (this._enabled && this._started) {
+      this._core.tracer.info(`There are ${this._core.behaviors.count} behaviors available`);
+    }
+  }
+
+  start(core) {
+    this._started = true;
+    core.tracer.debug("traceMocks plugin started");
+    this.traceBehaviors();
+  }
+
+  stop(core) {
+    this._started = false;
+    core.tracer.debug("traceMocks plugin stopped");
+  }
+
+  _onChangeSettings(settings) {
+    if (settings.hasOwnProperty("traceMocks")) {
+      this._enabled = settings.traceMocks;
+    }
+  }
+
+  _onChangeMocks() {
+    this.traceBehaviors();
+  }
+}
+
+module.exports = Plugin;

--- a/test/acceptance/fixtures/config-files/TraceMocksPlugin2.js
+++ b/test/acceptance/fixtures/config-files/TraceMocksPlugin2.js
@@ -1,0 +1,54 @@
+class Plugin {
+  constructor(core) {
+    core.addSetting({
+      name: "traceMocks2",
+      type: "boolean",
+      description: "Trace mocks changes",
+      default: true
+    });
+
+    this._core = core;
+    this._onChangeMocks = this._onChangeMocks.bind(this);
+    this._onChangeSettings = this._onChangeSettings.bind(this);
+  }
+
+  get displayName() {
+    return "trace-mocks";
+  }
+
+  init(core) {
+    this._enabled = core.settings.get("traceMocks2");
+    this._removeChangeMocksListener = core.onChangeMocks(this.onChangeMocks);
+    this._removeChangeSettingsListener = core.onChangeSettings(this.onChangeSettings);
+    core.tracer.debug(`traceMocks2 initial value is ${core.settings.get("traceMocks2")}`);
+  }
+
+  traceBehaviors() {
+    if (this._enabled && this._started) {
+      this._core.tracer.info(`Hey!, ${this._core.behaviors.count} behaviors available`);
+    }
+  }
+
+  start(core) {
+    this._started = true;
+    core.tracer.debug("traceMocks2 plugin started");
+    this.traceBehaviors();
+  }
+
+  stop(core) {
+    this._started = false;
+    core.tracer.debug("traceMocks2 plugin stopped");
+  }
+
+  _onChangeSettings(settings) {
+    if (settings.hasOwnProperty("traceMocks2")) {
+      this._enabled = settings.traceMocks2;
+    }
+  }
+
+  _onChangeMocks() {
+    this.traceBehaviors();
+  }
+}
+
+module.exports = Plugin;

--- a/test/acceptance/fixtures/config-files/add-plugins.config.js
+++ b/test/acceptance/fixtures/config-files/add-plugins.config.js
@@ -1,0 +1,12 @@
+const path = require("path");
+const TraceMocksPlugin2 = require("./TraceMocksPlugin2");
+
+module.exports = {
+  addPlugins: [TraceMocksPlugin2],
+  options: {
+    log: "silly",
+    traceMocks: true,
+    behavior: "user2",
+    path: path.resolve(__dirname, "..", "web-tutorial-json")
+  }
+};

--- a/test/acceptance/fixtures/config-files/mocks-server.config.js
+++ b/test/acceptance/fixtures/config-files/mocks-server.config.js
@@ -1,0 +1,12 @@
+const path = require("path");
+const TraceMocksPlugin = require("./TraceMocksPlugin");
+
+module.exports = {
+  plugins: [TraceMocksPlugin],
+  options: {
+    log: "silly",
+    traceMocks: true,
+    behavior: "user2",
+    path: path.resolve(__dirname, "..", "web-tutorial-json")
+  }
+};

--- a/test/acceptance/fixtures/config-files/starter
+++ b/test/acceptance/fixtures/config-files/starter
@@ -1,0 +1,21 @@
+#!/usr/bin/env node
+"use strict";
+
+const { Core } = require("../../../../index");
+
+const handleError = error => {
+  console.error(`Error: ${error.message}`);
+  process.exitCode = 1;
+};
+
+const start = () => {
+  try {
+    const mocksServer = new Core();
+
+    return mocksServer.start().catch(handleError);
+  } catch (error) {
+    return handleError(error);
+  }
+};
+
+start();

--- a/test/acceptance/fixtures/config-files/starter-add-plugins
+++ b/test/acceptance/fixtures/config-files/starter-add-plugins
@@ -1,0 +1,25 @@
+#!/usr/bin/env node
+"use strict";
+
+const { Core } = require("../../../../index");
+const TraceMocksPlugin = require("./TraceMocksPlugin");
+
+const handleError = error => {
+  console.error(`Error: ${error.message}`);
+  process.exitCode = 1;
+};
+
+const start = () => {
+  try {
+    const mocksServer = new Core({
+      plugins: [TraceMocksPlugin],
+      configFile: "add-plugins.config.js"
+    });
+
+    return mocksServer.start().catch(handleError);
+  } catch (error) {
+    return handleError(error);
+  }
+};
+
+start();

--- a/test/unit/Config.mocks.js
+++ b/test/unit/Config.mocks.js
@@ -1,0 +1,42 @@
+/*
+Copyright 2019 Javier Brea
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+*/
+
+const sinon = require("sinon");
+
+jest.mock("../../src/Config");
+
+const Config = require("../../src/Config");
+
+class ConfigMock {
+  constructor() {
+    this._sandbox = sinon.createSandbox();
+
+    this._stubs = {
+      init: this._sandbox.stub().resolves(),
+      coreOptions: {},
+      options: {}
+    };
+
+    Config.mockImplementation(() => this._stubs);
+  }
+
+  get stubs() {
+    return {
+      Constructor: Config,
+      instance: this._stubs
+    };
+  }
+
+  restore() {
+    this._sandbox.restore();
+  }
+}
+
+module.exports = ConfigMock;

--- a/test/unit/Config.spec.js
+++ b/test/unit/Config.spec.js
@@ -243,6 +243,29 @@ describe("Config", () => {
       });
     });
 
+    it("should pass programmatic config to function to allow modify it", async () => {
+      expect.assertions(2);
+      config = new Config({
+        configFile: "config.modify.js",
+        disableCommandLineArguments: true,
+        plugins: ["foo"],
+        options: {
+          foo: "foo"
+        }
+      });
+      await config.init({
+        foo2: "foo2"
+      });
+      expect(config.coreOptions).toEqual({
+        configFile: "config.modify.js",
+        plugins: ["foo", "foo2"]
+      });
+      expect(config.options).toEqual({
+        foo2: "foo2",
+        foo3: "foo3"
+      });
+    });
+
     it("should trace error when file export a not valid object", async () => {
       expect.assertions(2);
       config = new Config({

--- a/test/unit/Config.spec.js
+++ b/test/unit/Config.spec.js
@@ -1,0 +1,306 @@
+/*
+Copyright 2019 Javier Brea
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+*/
+
+const sinon = require("sinon");
+const path = require("path");
+const fsExtra = require("fs-extra");
+
+const Config = require("../../src/Config");
+const tracer = require("../../src/tracer");
+
+describe("Config", () => {
+  let sandbox;
+  let config;
+  const FIXTURES_FOLDER = path.resolve(__dirname, "fixtures", "config");
+
+  beforeEach(async () => {
+    sandbox = sinon.createSandbox();
+    sandbox.stub(tracer, "info");
+    sandbox.stub(tracer, "error");
+    sandbox.stub(tracer, "set");
+    sandbox.stub(process, "cwd").returns(FIXTURES_FOLDER);
+    sandbox.spy(path, "resolve");
+    sandbox.spy(fsExtra, "pathExists");
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  describe("when created", () => {
+    it("should init coreOptions as empty object if no received", async () => {
+      config = new Config();
+      expect(config.coreOptions).toEqual({});
+    });
+
+    it("should set disableCommandLineArguments as true if onlyProgrammaticOptions is true", async () => {
+      config = new Config({
+        onlyProgrammaticOptions: true
+      });
+      expect(config.coreOptions.disableCommandLineArguments).toEqual(true);
+    });
+
+    it("should set disableCommandLineArguments as false if it is explictly defined", async () => {
+      config = new Config({
+        onlyProgrammaticOptions: true,
+        disableCommandLineArguments: false
+      });
+      expect(config.coreOptions.disableCommandLineArguments).toEqual(false);
+    });
+
+    it("should set disableConfigFile as true if onlyProgrammaticOptions is true", async () => {
+      config = new Config({
+        onlyProgrammaticOptions: true
+      });
+      expect(config.coreOptions.disableConfigFile).toEqual(true);
+    });
+
+    it("should set disableConfigFile as false if it is explictly defined", async () => {
+      config = new Config({
+        onlyProgrammaticOptions: true,
+        disableConfigFile: false
+      });
+      expect(config.coreOptions.disableConfigFile).toEqual(false);
+    });
+
+    it("should set plugins received programmatically", async () => {
+      config = new Config({
+        plugins: "foo"
+      });
+      expect(config.coreOptions.plugins).toEqual("foo");
+    });
+
+    it("should set plugins received programmatically", async () => {
+      config = new Config({
+        configFile: "/foo"
+      });
+      expect(config.coreOptions.configFile).toEqual("/foo");
+    });
+
+    it("should set received options", async () => {
+      config = new Config({
+        options: {
+          foo: "foo"
+        }
+      });
+      expect(config.options).toEqual({
+        foo: "foo"
+      });
+    });
+
+    it("should set log level if option log is received", async () => {
+      config = new Config({
+        options: {
+          log: "silly"
+        }
+      });
+      expect(tracer.set.calledWith("silly")).toEqual(true);
+    });
+  });
+
+  describe("When initialized", () => {
+    it("should extend core programmatic options with init method options", async () => {
+      config = new Config({
+        options: {
+          foo: "foo",
+          foo2: "foo-2"
+        }
+      });
+      await config.init({
+        foo2: "foo2",
+        foo3: "foo3"
+      });
+      expect(config.options).toEqual({
+        foo: "foo",
+        foo2: "foo2",
+        foo3: "foo3"
+      });
+    });
+  });
+
+  describe("When reading config file", () => {
+    it("should not try to read config file if disableConfigFile is true", async () => {
+      config = new Config({
+        disableConfigFile: true
+      });
+      await config.init();
+      expect(fsExtra.pathExists.callCount).toEqual(0);
+    });
+
+    it("should try to read file named mocks-server.config.js in cwd by default", async () => {
+      config = new Config();
+      await config.init();
+      expect(fsExtra.pathExists.getCall(0).args[0]).toEqual(
+        path.resolve(FIXTURES_FOLDER, "mocks-server.config.js")
+      );
+    });
+
+    it("should try to read custom file path from cwd if it is relative", async () => {
+      config = new Config({
+        configFile: "foo-config.js"
+      });
+      await config.init();
+      expect(fsExtra.pathExists.getCall(0).args[0]).toEqual(
+        path.resolve(FIXTURES_FOLDER, "foo-config.js")
+      );
+    });
+
+    it("should try to read custom file path if it is absolute", async () => {
+      config = new Config({
+        configFile: path.resolve(__dirname, "foo.js")
+      });
+      await config.init();
+      expect(fsExtra.pathExists.getCall(0).args[0]).toEqual(path.resolve(__dirname, "foo.js"));
+    });
+
+    it("should trace if configuration file is not found", async () => {
+      config = new Config({
+        configFile: "foo-config.js"
+      });
+      await config.init();
+      expect(tracer.info.calledWith("Configuration file not found")).toEqual(true);
+    });
+
+    it("should extend programmatic, initialization and file options", async () => {
+      expect.assertions(2);
+      config = new Config({
+        configFile: "config.object.js",
+        options: {
+          foo: "foo",
+          foo2: "foo-2"
+        }
+      });
+      await config.init({
+        foo2: "foo2",
+        foo3: "foo3",
+        delay: 500
+      });
+      expect(config.coreOptions).toEqual({
+        configFile: "config.object.js",
+        plugins: ["foo"]
+      });
+      expect(config.options).toEqual({
+        foo: "foo",
+        foo2: "foo2",
+        foo3: "foo3",
+        log: "silly",
+        delay: 1000
+      });
+    });
+
+    it("should read configuration when defined as an object", async () => {
+      expect.assertions(2);
+      config = new Config({
+        configFile: "config.object.js"
+      });
+      await config.init();
+      expect(config.coreOptions).toEqual({
+        configFile: "config.object.js",
+        plugins: ["foo"]
+      });
+      expect(config.options).toEqual({
+        log: "silly",
+        delay: 1000
+      });
+    });
+
+    it("should read configuration when defined as a function", async () => {
+      expect.assertions(2);
+      config = new Config({
+        configFile: "config.function.js"
+      });
+      await config.init();
+      expect(config.coreOptions).toEqual({
+        configFile: "config.function.js",
+        plugins: ["foo"]
+      });
+      expect(config.options).toEqual({
+        log: "silly",
+        delay: 1000
+      });
+    });
+
+    it("should read configuration when defined as a promise", async () => {
+      expect.assertions(2);
+      config = new Config({
+        configFile: "config.promise.js"
+      });
+      await config.init();
+      expect(config.coreOptions).toEqual({
+        configFile: "config.promise.js",
+        plugins: ["foo"]
+      });
+      expect(config.options).toEqual({
+        log: "silly",
+        delay: 1000
+      });
+    });
+
+    it("should trace error when file export a not valid object", async () => {
+      expect.assertions(2);
+      config = new Config({
+        configFile: "config.export-invalid.js"
+      });
+      await config.init();
+      expect(tracer.error.calledWith("Error in configuration file")).toEqual(true);
+      expect(config.options).toEqual({});
+    });
+
+    it("should trace error when promise returns a not valid object", async () => {
+      expect.assertions(2);
+      config = new Config({
+        configFile: "config.promise-invalid.js"
+      });
+      await config.init();
+      expect(tracer.error.calledWith("Error in configuration file")).toEqual(true);
+      expect(config.options).toEqual({});
+    });
+
+    it("should trace error when function returns a not valid object", async () => {
+      expect.assertions(2);
+      config = new Config({
+        configFile: "config.function-invalid.js"
+      });
+      await config.init();
+      expect(tracer.error.calledWith("Error in configuration file")).toEqual(true);
+      expect(config.options).toEqual({});
+    });
+
+    it("should trace error when file throws an error", async () => {
+      expect.assertions(2);
+      config = new Config({
+        configFile: "config.export-error.js"
+      });
+      await config.init();
+      expect(tracer.error.calledWith("Error in configuration file")).toEqual(true);
+      expect(config.options).toEqual({});
+    });
+
+    it("should trace error when function throws an error", async () => {
+      expect.assertions(2);
+      config = new Config({
+        configFile: "config.function-error.js"
+      });
+      await config.init();
+      expect(tracer.error.calledWith("Error in configuration file")).toEqual(true);
+      expect(config.options).toEqual({});
+    });
+
+    it("should trace error when promise is rejected", async () => {
+      expect.assertions(2);
+      config = new Config({
+        configFile: "config.promise-rejected.js"
+      });
+      await config.init();
+      expect(tracer.error.calledWith("Error in configuration file")).toEqual(true);
+      expect(config.options).toEqual({});
+    });
+  });
+});

--- a/test/unit/Config.spec.js
+++ b/test/unit/Config.spec.js
@@ -77,7 +77,14 @@ describe("Config", () => {
       expect(config.coreOptions.plugins).toEqual("foo");
     });
 
-    it("should set plugins received programmatically", async () => {
+    it("should add plugins received programmatically", async () => {
+      config = new Config({
+        addPlugins: ["foo"]
+      });
+      expect(config.coreOptions.plugins).toEqual(["foo"]);
+    });
+
+    it("should set configFile received programmatically", async () => {
       config = new Config({
         configFile: "/foo"
       });
@@ -192,6 +199,18 @@ describe("Config", () => {
         foo3: "foo3",
         log: "silly",
         delay: 1000
+      });
+    });
+
+    it("should add plugins received in addPlugins option", async () => {
+      config = new Config({
+        configFile: "config.add-plugins.js",
+        plugins: ["foo"]
+      });
+      await config.init();
+      expect(config.coreOptions).toEqual({
+        configFile: "config.add-plugins.js",
+        plugins: ["foo", "foo2"]
       });
     });
 

--- a/test/unit/Config.spec.js
+++ b/test/unit/Config.spec.js
@@ -262,6 +262,22 @@ describe("Config", () => {
       });
     });
 
+    it("should read configuration when defined as an async function", async () => {
+      expect.assertions(2);
+      config = new Config({
+        configFile: "config.async.js"
+      });
+      await config.init();
+      expect(config.coreOptions).toEqual({
+        configFile: "config.async.js",
+        plugins: ["foo"]
+      });
+      expect(config.options).toEqual({
+        log: "silly",
+        delay: 1000
+      });
+    });
+
     it("should pass programmatic config to function to allow modify it", async () => {
       expect.assertions(2);
       config = new Config({

--- a/test/unit/Core.spec.js
+++ b/test/unit/Core.spec.js
@@ -15,6 +15,7 @@ const MocksMocks = require("./mocks/Mocks.mocks.js");
 const ServerMocks = require("./server/Server.mocks.js");
 const PluginsMocks = require("./plugins/Plugins.mocks.js");
 const OrchestratorMocks = require("./Orchestrator.mocks.js");
+const ConfigMocks = require("./Config.mocks.js");
 
 const Core = require("../../src/Core");
 const tracer = require("../../src/tracer");
@@ -30,6 +31,7 @@ describe("Core", () => {
   let serverInstance;
   let pluginsMocks;
   let pluginsInstance;
+  let configMocks;
   let core;
 
   beforeEach(async () => {
@@ -43,6 +45,7 @@ describe("Core", () => {
     pluginsMocks = new PluginsMocks();
     pluginsInstance = pluginsMocks.stubs.instance;
     orchestratorMocks = new OrchestratorMocks();
+    configMocks = new ConfigMocks();
 
     core = new Core();
     await core.init();
@@ -54,7 +57,16 @@ describe("Core", () => {
     mocksMocks.restore();
     orchestratorMocks.restore();
     serverMocks.restore();
+    configMocks.restore();
     pluginsMocks.restore();
+  });
+
+  describe("when created", () => {
+    it("should create Config with received config", () => {
+      const fooConfig = { foo: "foo" };
+      core = new Core(fooConfig);
+      expect(configMocks.stubs.Constructor.mock.calls[1][0]).toEqual(fooConfig);
+    });
   });
 
   describe("init method", () => {
@@ -68,13 +80,10 @@ describe("Core", () => {
       expect(pluginsInstance.register.callCount).toEqual(1);
     });
 
-    it("should init settings with received options", async () => {
-      const fooOptions = {
-        foo: "foo"
-      };
+    it("should init settings with config options", async () => {
       core = new Core();
-      await core.init(fooOptions);
-      expect(settingsInstance.init.calledWith(fooOptions)).toEqual(true);
+      await core.init();
+      expect(settingsInstance.init.calledWith(configMocks.stubs.instance.options)).toEqual(true);
     });
 
     it("should init mocks", () => {

--- a/test/unit/fixtures/config/config.add-plugins.js
+++ b/test/unit/fixtures/config/config.add-plugins.js
@@ -1,0 +1,3 @@
+module.exports = {
+  addPlugins: ["foo2"]
+};

--- a/test/unit/fixtures/config/config.async.js
+++ b/test/unit/fixtures/config/config.async.js
@@ -1,0 +1,14 @@
+const getAsyncLog = () => {
+  return Promise.resolve("silly");
+};
+
+module.exports = async () => {
+  const log = await getAsyncLog();
+  return {
+    plugins: ["foo"],
+    options: {
+      log,
+      delay: 1000
+    }
+  };
+};

--- a/test/unit/fixtures/config/config.export-error.js
+++ b/test/unit/fixtures/config/config.export-error.js
@@ -1,0 +1,1 @@
+throw new Error();

--- a/test/unit/fixtures/config/config.export-invalid.js
+++ b/test/unit/fixtures/config/config.export-invalid.js
@@ -1,0 +1,1 @@
+module.exports = "foo";

--- a/test/unit/fixtures/config/config.function-error.js
+++ b/test/unit/fixtures/config/config.function-error.js
@@ -1,0 +1,3 @@
+module.exports = () => {
+  throw new Error();
+};

--- a/test/unit/fixtures/config/config.function-invalid.js
+++ b/test/unit/fixtures/config/config.function-invalid.js
@@ -1,0 +1,3 @@
+module.exports = () => {
+  return "foo";
+};

--- a/test/unit/fixtures/config/config.function.js
+++ b/test/unit/fixtures/config/config.function.js
@@ -1,0 +1,7 @@
+module.exports = () => ({
+  plugins: ["foo"],
+  options: {
+    log: "silly",
+    delay: 1000
+  }
+});

--- a/test/unit/fixtures/config/config.modify.js
+++ b/test/unit/fixtures/config/config.modify.js
@@ -1,0 +1,7 @@
+module.exports = config => {
+  delete config.disableCommandLineArguments;
+  config.plugins.push("foo2");
+  delete config.options.foo;
+  config.options.foo3 = "foo3";
+  return config;
+};

--- a/test/unit/fixtures/config/config.object.js
+++ b/test/unit/fixtures/config/config.object.js
@@ -1,0 +1,7 @@
+module.exports = {
+  plugins: ["foo"],
+  options: {
+    log: "silly",
+    delay: 1000
+  }
+};

--- a/test/unit/fixtures/config/config.promise-invalid.js
+++ b/test/unit/fixtures/config/config.promise-invalid.js
@@ -1,0 +1,3 @@
+module.exports = () => {
+  return Promise.resolve(5);
+};

--- a/test/unit/fixtures/config/config.promise-rejected.js
+++ b/test/unit/fixtures/config/config.promise-rejected.js
@@ -1,0 +1,3 @@
+module.exports = () => {
+  return Promise.reject(new Error());
+};

--- a/test/unit/fixtures/config/config.promise.js
+++ b/test/unit/fixtures/config/config.promise.js
@@ -1,0 +1,9 @@
+module.exports = () => {
+  return Promise.resolve({
+    plugins: ["foo"],
+    options: {
+      log: "silly",
+      delay: 1000
+    }
+  });
+};

--- a/test/unit/settings/Settings.spec.js
+++ b/test/unit/settings/Settings.spec.js
@@ -13,6 +13,7 @@ const sinon = require("sinon");
 
 const OptionsMocks = require("./Options.mocks.js");
 const CoreMocks = require("../Core.mocks.js");
+const ConfigMocks = require("../Config.mocks.js");
 
 const Settings = require("../../../src/settings/Settings");
 const tracer = require("../../../src/tracer");
@@ -22,6 +23,7 @@ describe("Settings", () => {
   let optionsInstance;
   let coreMocks;
   let coreInstance;
+  let configMocks;
   let sandbox;
   let settings;
 
@@ -31,10 +33,11 @@ describe("Settings", () => {
     optionsInstance = optionsMocks.stubs.instance;
     optionsInstance.checkValidOptionName.callsFake(name => name);
     coreMocks = new CoreMocks();
+    configMocks = new ConfigMocks();
     coreInstance = coreMocks.stubs.instance;
     sandbox.stub(tracer, "set");
     sandbox.stub(tracer, "info");
-    settings = new Settings(coreInstance._eventEmitter, {});
+    settings = new Settings(coreInstance._eventEmitter, configMocks.stubs.instance);
     await settings.init();
   });
 
@@ -42,6 +45,7 @@ describe("Settings", () => {
     sandbox.restore();
     optionsMocks.restore();
     coreMocks.restore();
+    configMocks.restore();
   });
 
   describe("when initializated", () => {


### PR DESCRIPTION
### Added
- Add "addPlugins" configuration.
- Add "disableCommandLineArguments" configuration.
- Add "disableConfigFile" configuration.
- Load configuration and options from file.
- Options can also be passed to the Core Constructor, using the "options" key in the config object.

closes #13 