### PR TITLE
Disable validations if ajv-errors initialization fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 ### Changed
 ### Fixed
+- fix: Disable validations if ajv-errors initialization fails. Add an alert with a link to https://mocks-server.org/docs/how-to-fix-ajv-errors-installation in that case
 ### Removed
 ### BREAKING CHANGES
 

--- a/src/mocks/Mocks.js
+++ b/src/mocks/Mocks.js
@@ -20,7 +20,7 @@ const {
   getMocks,
   getMock,
 } = require("./helpers");
-const { getIds, compileRouteValidator } = require("./validations");
+const { getIds, compileRouteValidator, catchInitValidatorError } = require("./validations");
 
 class Mocks {
   constructor(
@@ -107,6 +107,14 @@ class Mocks {
   }
 
   init(routesHandlers) {
+    if (catchInitValidatorError()) {
+      this._addAlert(
+        "validation:init",
+        new Error(
+          "Error loading ajv-errors dependency, validations won't be executed. Visit https://mocks-server.org/docs/how-to-fix-ajv-errors-installation for further info."
+        )
+      );
+    }
     compileRouteValidator(routesHandlers);
     this._routesVariantsHandlers = routesHandlers;
   }

--- a/test/unit/mocks/Mocks.spec.js
+++ b/test/unit/mocks/Mocks.spec.js
@@ -14,6 +14,7 @@ const express = require("express");
 const MockMock = require("./Mock.mock.js");
 
 const Mocks = require("../../../src/mocks/Mocks");
+const { undoInitValidator, restoreValidator } = require("../../../src/mocks/validations");
 const DefaultRoutesHandler = require("../../../src/routes-handlers/default/DefaultRoutesHandler");
 
 describe("Mocks", () => {
@@ -48,6 +49,18 @@ describe("Mocks", () => {
   afterEach(() => {
     sandbox.restore();
     mockMock.restore();
+  });
+
+  describe("init method", () => {
+    afterAll(() => {
+      restoreValidator();
+    });
+
+    it("should add an alert if there is an error initializing validator", () => {
+      undoInitValidator();
+      mocks.init([DefaultRoutesHandler]);
+      expect(methods.addAlert.getCall(0).args[0]).toEqual("validation:init");
+    });
   });
 
   describe("load method", () => {

--- a/test/unit/mocks/helpers.spec.js
+++ b/test/unit/mocks/helpers.spec.js
@@ -24,7 +24,10 @@ const {
   getRouteVariants,
   getMock,
 } = require("../../../src/mocks/helpers");
-const { compileRouteValidator } = require("../../../src/mocks/validations");
+const {
+  compileRouteValidator,
+  catchInitValidatorError,
+} = require("../../../src/mocks/validations");
 const DefaultRoutesHandler = require("../../../src/routes-handlers/default/DefaultRoutesHandler");
 
 describe("mocks helpers", () => {
@@ -61,6 +64,7 @@ describe("mocks helpers", () => {
   let sandbox, addAlert, removeAlerts;
 
   beforeAll(() => {
+    catchInitValidatorError();
     compileRouteValidator([{ id: "foo-handler" }]);
   });
 

--- a/test/unit/mocks/validations.spec.js
+++ b/test/unit/mocks/validations.spec.js
@@ -16,6 +16,9 @@ const {
   variantValidationErrors,
   mockValidationErrors,
   mockRouteVariantsValidationErrors,
+  catchInitValidatorError,
+  undoInitValidator,
+  restoreValidator,
 } = require("../../../src/mocks/validations");
 const DefaultRoutesHandler = require("../../../src/routes-handlers/default/DefaultRoutesHandler");
 
@@ -41,6 +44,62 @@ describe("mocks validations", () => {
       body: {},
     },
   };
+
+  beforeAll(() => {
+    catchInitValidatorError();
+  });
+
+  describe("validation initialization", () => {
+    afterAll(() => {
+      restoreValidator();
+    });
+
+    describe("catchInitValidatorError", () => {
+      it("should return error if there is an error initializating validator", () => {
+        undoInitValidator();
+        expect(catchInitValidatorError()).toBeInstanceOf(Error);
+      });
+
+      it("should do nothing if validator was already inited", () => {
+        restoreValidator();
+        expect(catchInitValidatorError()).toEqual(null);
+      });
+    });
+
+    describe("compileRouteValidator", () => {
+      it("should initialize a fake routeValidator if there was an error initializating validator", () => {
+        undoInitValidator();
+        compileRouteValidator();
+        expect(
+          routeValidationErrors({
+            ...VALID_ROUTE,
+            id: undefined,
+          })
+        ).toEqual(null);
+      });
+    });
+
+    describe("undo init validator", () => {
+      it("should not fail if called twice", () => {
+        undoInitValidator();
+        undoInitValidator();
+        expect(
+          routeValidationErrors({
+            ...VALID_ROUTE,
+            id: undefined,
+          })
+        ).toEqual(null);
+      });
+    });
+
+    describe("restore validator", () => {
+      it("should not fail if called twice", () => {
+        restoreValidator();
+        restoreValidator();
+        expect(catchInitValidatorError()).toEqual(null);
+      });
+    });
+  });
 
   describe("getIds", () => {
     it("should return array with ids", () => {


### PR DESCRIPTION
## Fixed
- fix: Disable validations if ajv-errors initialization fails. Add an alert with a link to https://mocks-server.org/docs/how-to-fix-ajv-errors-installation in that case
