### PR TITLE
feat(#201): form body parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased]
 ### Added
+* parsing of body with content-type application/x-www-form-urlencoded 
 ### Changed
 ### Fixed
 ### Removed

--- a/src/server/Server.js
+++ b/src/server/Server.js
@@ -63,6 +63,7 @@ class Server {
       );
     }
     this._express.use(middlewares.jsonBodyParser);
+    this._express.use(middlewares.formBodyParser);
     this._express.use(middlewares.traceRequest);
     this._registerCustomRouters();
     this._express.use(this._mocksRouter);

--- a/src/server/middlewares.js
+++ b/src/server/middlewares.js
@@ -20,6 +20,7 @@ const tracer = require("../tracer");
 
 const addRequestId = expressRequestId();
 const jsonBodyParser = bodyParser.json();
+const formBodyParser = bodyParser.urlencoded({ extended: true });
 
 const traceRequest = (req, res, next) => {
   tracer.verbose(`Request received | ${req.method} => ${req.url} | Assigned id: ${req.id}`);
@@ -50,6 +51,7 @@ const errorHandler = (err, req, res, next) => {
 module.exports = {
   addRequestId,
   jsonBodyParser,
+  formBodyParser,
   traceRequest,
   notFound,
   errorHandler,

--- a/test/unit/server/Server.spec.js
+++ b/test/unit/server/Server.spec.js
@@ -238,7 +238,7 @@ describe("Server", () => {
       coreInstance.settings.get.withArgs("cors").returns(true);
       await server.init();
       await server.start();
-      expect(libsMocks.stubs.express.use.callCount).toEqual(8);
+      expect(libsMocks.stubs.express.use.callCount).toEqual(9);
     });
 
     it("should not add cors middleware if cors option is disabled", async () => {
@@ -246,7 +246,7 @@ describe("Server", () => {
       coreInstance.settings.get.withArgs("cors").returns(false);
       await server.init();
       await server.start();
-      expect(libsMocks.stubs.express.use.callCount).toEqual(7);
+      expect(libsMocks.stubs.express.use.callCount).toEqual(8);
     });
 
     it("should reject the promise if an error occurs when calling to server listen method", async () => {


### PR DESCRIPTION
PR for issue https://github.com/mocks-server/core/issues/201

Added the express body parser for forms. Issue was, that the form parameters have not been accessible through
req.params.NAME.

Change is requested because not always there is only JSON to be processed in projects. Some parts (older backends/apis or standards in use (OIDC for example) require the process application/x-www-form-urlencoded content. 