### PR TITLE
Routes validator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 - fix: validation of added route handlers was not working due to ajv cache
+
 ## [2.5.1] - 2021-12-04
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Removed
 ### BREAKING CHANGES
 
+## [unreleased]
+
+### Fixed
+- fix: validation of added route handlers was not working due to ajv cache
 ## [2.5.1] - 2021-12-04
 
 ### Fixed

--- a/src/mocks/validations.js
+++ b/src/mocks/validations.js
@@ -217,11 +217,12 @@ function getIds(objs) {
 function compileRouteValidator(routesHandlers) {
   if (validatorInited) {
     const supportedRouteHandlersIds = getIds(routesHandlers);
-    routesSchema.properties.variants.items.properties.handler.enum = supportedRouteHandlersIds;
-    routesSchema.properties.variants.items.properties.handler.errorMessage = `Property "handler" should be one of "${supportedRouteHandlersIds.join(
+    const schema = { ...routesSchema };
+    schema.properties.variants.items.properties.handler.enum = supportedRouteHandlersIds;
+    schema.properties.variants.items.properties.handler.errorMessage = `Property "handler" should be one of "${supportedRouteHandlersIds.join(
       ","
     )}" in variant \${1#}`;
-    routeValidator = ajv.compile(routesSchema);
+    routeValidator = ajv.compile(schema);
   } else {
     routeValidator = fooValidator;
   }

--- a/test/unit/mocks/validations.spec.js
+++ b/test/unit/mocks/validations.spec.js
@@ -283,6 +283,24 @@ describe("mocks validations", () => {
     });
   });
 
+  describe("when adding routeHandlers to routeValidation", () => {
+    it("routeValidationErrors should return null if routes uses new handler", () => {
+      compileRouteValidator([{ id: "foo-handler" }, { id: "foo-new-handler" }]);
+      const errors = routeValidationErrors({
+        id: "foo-new-route",
+        url: "/foo",
+        method: "POST",
+        variants: [
+          {
+            id: "foo-new-variant",
+            handler: "foo-new-handler",
+          },
+        ],
+      });
+      expect(errors).toEqual(null);
+    });
+  });
+
   describe("variantValidationErrors", () => {
     it("should return null if Hanlder has not validationSchema", () => {
       expect(variantValidationErrors({}, {}, {})).toEqual(null);


### PR DESCRIPTION
- fix: validation of added route handlers was not working due to ajv cache